### PR TITLE
fixing a circular import

### DIFF
--- a/src/data_acquisition/entso_e/entso_e.py
+++ b/src/data_acquisition/entso_e/entso_e.py
@@ -1,13 +1,11 @@
 from typing import Optional
 
-import pandas as pd
 from entsoe import EntsoePandasClient
 import os
 import pandas as pd
 from dateutil.relativedelta import relativedelta
 from dotenv import load_dotenv
 
-from src.data_acquisition.entso_e.entso_e import EntsoeHook
 from src.data_acquisition.postgres_db.postgres_db_hooks import ThesisDBHook
 
 load_dotenv()


### PR DESCRIPTION
```
  File "/Users/.../.../BessBidder/src/data_acquisition/entso_e/entso_e.py", line 10, in <module>
    from src.data_acquisition.entso_e.entso_e import EntsoeHook
ImportError: cannot import name 'EntsoeHook' from partially initialized module 'src.data_acquisition.entso_e.entso_e' (most likely due to a circular import) (/Users/.../.../BessBidder/src/data_acquisition/entso_e/entso_e.py)
```

I noticed, that inside the entso_e file we were importing the EntsoeHook. This PR removes it.

also threw out duplicated pandas import