### PR TITLE
fix keyerror with full time range

### DIFF
--- a/02a_single_market_day_ahead_milp.py
+++ b/02a_single_market_day_ahead_milp.py
@@ -70,14 +70,11 @@ def main():
     Solve daily MILP battery optimisation problems for all days in the simulation range.
     Results are saved to disk as a single CSV file.
     """
-    # Extend time range to ensure full coverage
-    start = START - pd.Timedelta(days=1)
-    end = END + pd.Timedelta(days=1)
 
     # Get daily timestamps
     days = [
         t.date().isoformat()
-        for t in pd.date_range(start, end - pd.Timedelta(days=1), freq="1d")
+        for t in pd.date_range(START, END - pd.Timedelta(days=1), freq="1d")
     ]
 
     data = load_data()

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -16,8 +16,8 @@ BUCKET_SIZE = 15
 MIN_TRADES = 10
 
 # Define model horizon
-START = pd.Timestamp(year=2020, month=10, day=31, tz="Europe/Berlin")
-END = pd.Timestamp(year=2020, month=12, day=31, tz="Europe/Berlin")
+START = pd.Timestamp(year=2019, month=1, day=1, tz="Europe/Berlin")
+END = pd.Timestamp(year=2024, month=1, day=1, tz="Europe/Berlin")
 
 # ----------------------------------------------
 # MODELLING CONFIGURATIONS


### PR DESCRIPTION
When i am using the full time range 

```python
START = pd.Timestamp(year=2019, month=1, day=1, tz="Europe/Berlin")
END = pd.Timestamp(year=2024, month=1, day=1, tz="Europe/Berlin")
```

i get:

```
  File "/Users/.../.../BessBidder/venv/lib/python3.12/site-packages/pandas/core/indexes/datetimes.py", line 612, in get_loc
    raise KeyError(key) from err
KeyError: '2018-12-31'
```
